### PR TITLE
Fix CDN OTP script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Auth
-Two method Auth
+
+Example PWA that demonstrates two authentication methods:
+1. Login through Keycloak.
+2. One-time password (OTP) that can be stored in a password manager.
+
+The `pwa` folder contains a minimal implementation. Update `app.js` with your Keycloak server settings. OTP verification uses the [jsotp](https://github.com/hectorm/jsotp) library loaded from jsDelivr.
+
+### Running locally
+Serve the `pwa` folder with any static file server, for example:
+
+```bash
+npx serve pwa
+```
+
+Then open `http://localhost:3000` in a browser.

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -1,0 +1,39 @@
+const keycloakConfig = {
+  url: 'https://your-keycloak-server/auth',
+  realm: 'your-realm',
+  clientId: 'your-client-id'
+};
+
+const keycloak = new Keycloak(keycloakConfig);
+
+document.getElementById('login-keycloak').addEventListener('click', () => {
+  keycloak.init({ onLoad: 'login-required' }).then(authenticated => {
+    if (authenticated) {
+      document.getElementById('result').textContent = 'Logged in with Keycloak. Token: ' + keycloak.token;
+    } else {
+      document.getElementById('result').textContent = 'Keycloak authentication failed';
+    }
+  }).catch(err => {
+    document.getElementById('result').textContent = 'Error: ' + err;
+  });
+});
+
+// OTP login example
+const otpSecret = 'JBSWY3DPEHPK3PXP'; // demo secret for TOTP (Base32)
+
+document.getElementById('otp-submit').addEventListener('click', () => {
+  const otp = document.getElementById('otp').value.trim();
+  verifyOtp(otp);
+});
+
+function verifyOtp(otp) {
+  // Normally you would send the OTP to your backend for verification.
+  // Here we verify it in the client for demo purposes using jsotp.
+  try {
+    const totp = new jsotp.TOTP(otpSecret);
+    const isValid = totp.verify(otp);
+    document.getElementById('result').textContent = isValid ? 'OTP valid' : 'OTP invalid';
+  } catch (err) {
+    document.getElementById('result').textContent = 'Error: ' + err;
+  }
+}

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PWA Auth Example</title>
+  <link rel="manifest" href="manifest.json">
+  <script src="https://cdn.jsdelivr.net/npm/keycloak-js@22.0.4/dist/keycloak.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jsotp@1.0.4/lib/jsotp.min.js"></script>
+  <script defer src="app.js"></script>
+</head>
+<body>
+  <h1>PWA Auth Example</h1>
+  <button id="login-keycloak">Login with Keycloak</button>
+  <div id="otp-area">
+    <p>Or enter OTP from your password manager:</p>
+    <input type="text" id="otp" placeholder="Enter OTP" />
+    <button id="otp-submit">Submit OTP</button>
+  </div>
+  <div id="result"></div>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
+</body>
+</html>

--- a/pwa/manifest.json
+++ b/pwa/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "PWA Auth Example",
+  "short_name": "AuthPWA",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Example PWA with Keycloak and OTP login"
+}

--- a/pwa/service-worker.js
+++ b/pwa/service-worker.js
@@ -1,0 +1,16 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('auth-pwa-v1').then(cache => cache.addAll([
+      './',
+      './index.html',
+      './app.js',
+      './manifest.json'
+    ]))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- fix broken otplib CDN by using jsotp instead
- load jsotp in `index.html`
- document the OTP library in README

## Testing
- `npx serve pwa` *(fails: Need to install the following packages: serve@14.2.4)*

------
https://chatgpt.com/codex/tasks/task_e_6840a295ae0483218fad0290228e4c77